### PR TITLE
Fix write_lobs "invalid byte sequence in UTF-8"

### DIFF
--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -257,6 +257,8 @@ module ActiveRecord
             next unless value
             if klass.attribute_types[col.name].is_a? Type::Serialized
               value = klass.attribute_types[col.name].serialize(value)
+              # value can be nil after serialization because ActiveRecord serializes [] and {} as nil
+              next unless value
             end
             uncached do
               unless lob_record = select_one(sql = <<~SQL.squish, "Writable Large Object")

--- a/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
+++ b/lib/active_record/connection_adapters/oracle_enhanced/database_statements.rb
@@ -254,7 +254,7 @@ module ActiveRecord
           columns.each do |col|
             value = attributes[col.name]
             # changed sequence of next two lines - should check if value is nil before converting to yaml
-            next if value.blank?
+            next unless value
             if klass.attribute_types[col.name].is_a? Type::Serialized
               value = klass.attribute_types[col.name].serialize(value)
             end


### PR DESCRIPTION
write_lobs checks to see whether the value is blank before executing the SQL statement. If the LOB is binary, value.blank? call causes "invalid byte sequence in UTF-8" exception. We can instead use unless value, which is applicable both to strings and binary data.